### PR TITLE
Add ability to unmanage rndrelease file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ If set to false /etc/rndrelease will be deleted.
 - *Default*: true
 
 
+manage_rndrelease
+=================
+Boolean to trigger management of /etc/rndrelease file.
+If set to false /etc/rndrelease will not be managed.
+
+- *Default*: true
+
+
 create_symlink
 ==============
 Boolean to trigger creation of libtcl symlink.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@
 # Manages tcl-devel package, libtcl symlink and /etc/rndrelease.
 
 class arc (
+  $manage_rndrelease  = true,
   $create_rndrelease  = true,
   $create_symlink     = true,
   $install_package    = true,
@@ -93,6 +94,12 @@ class arc (
     $create_rndrelease_real = str2bool($create_rndrelease)
   }
 
+  if is_bool($manage_rndrelease) == true {
+    $manage_rndrelease_real = $manage_rndrelease
+  } else {
+    $manage_rndrelease_real = str2bool($manage_rndrelease)
+  }
+
   if is_bool($create_symlink) == true {
     $create_symlink_real = $create_symlink
   } else {
@@ -146,6 +153,7 @@ class arc (
   # <validating variables>
 
   validate_bool($create_rndrelease_real)
+  validate_bool($manage_rndrelease_real)
   validate_bool($create_symlink_real)
   validate_bool($install_package_real)
 
@@ -178,11 +186,13 @@ class arc (
     $rndrelease_ensure = 'present'
   }
 
-  file { 'arc_rndrelease':
-    ensure  => $rndrelease_ensure,
-    path    => '/etc/rndrelease',
-    mode    => '0644',
-    content => "${rndrelease_version_real}\n",
+  if $manage_rndrelease_real == true {
+    file { 'arc_rndrelease':
+      ensure  => $rndrelease_ensure,
+      path    => '/etc/rndrelease',
+      mode    => '0644',
+      content => "${rndrelease_version_real}\n",
+    }
   }
 
   if $::operatingsystem == 'Ubuntu' {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -399,6 +399,29 @@ describe 'arc' do
     end
   end
 
+  describe 'with manage_rndrelease set to false' do
+    ['false', false].each do |value|
+      context value do
+        let :facts do
+          { :operatingsystem        => 'RedHat',
+            :operatingsystemrelease => '5',
+            :architecture           => 'x86_64',
+          }
+        end
+        let :params do
+          { :manage_rndrelease => value,
+          }
+        end
+
+        it { should compile.with_all_deps }
+
+        it {
+          should_not contain_file('arc_rndrelease')
+        }
+      end
+    end
+  end
+
   describe 'with create_symlink set to' do
     ['false',false].each do |value|
       context value do


### PR DESCRIPTION
There may be a case where we do not want to remove
or modify the rndrelease file.