### PR TITLE
drop unneeded 32bit support for RH7

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,7 +32,7 @@ class arc (
     /^RedHat-7/: {
       $packages_default           = [ 'tcsh' ]
       $rndrelease_version_default = undef
-      $symlink_target_default     = '/usr/lib/libtcl.so.5'
+      $symlink_target_default     = undef
     }
     /^(SLED|SLES)-10/: {
       $packages_default = $::architecture ? {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -24,7 +24,7 @@ describe 'arc' do
         :architecture               => 'x86_64',
         :package_name_default       => [ 'tcsh' ],
         :rndrelease_version_default => nil,
-        :symlink_target_default     => '/usr/lib/libtcl.so.5',
+        :symlink_target_default     => nil,
       },
     'SLED-10.0 i386' =>
       { :operatingsystem            => 'SLED',


### PR DESCRIPTION
module binary is pure 64bit so we can drop 32bit support for RH7
<pre>
(10:24)user@host:~> which module
module:          aliased to eval `/app/modules/0/bin/modulecmd tcsh !*`
( (10:25)user@host:~> ldd /app/modules/0/bin/modulecmd
        linux-vdso.so.1 =>  (0x00007fffb61fe000)
        libtcl.so => /app/modules/3.1.6/lib/libtcl.so (0x00007f7020a38000)
        libdl.so.2 => /lib64/libdl.so.2 (0x00007f7020812000)
        libm.so.6 => /lib64/libm.so.6 (0x00007f7020510000)
        libc.so.6 => /lib64/libc.so.6 (0x00007f702014f000)
        libz.so.1 => /lib64/libz.so.1 (0x00007f701ff38000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f701fd1c000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f7020dd7000)
(10:25)user@host:~> ldd /app/modules/3.1.6/lib/libtcl.so
        linux-vdso.so.1 =>  (0x00007ffc75083000)
        libdl.so.2 => /lib64/libdl.so.2 (0x00007f3bd5b2b000)
        libz.so.1 => /lib64/libz.so.1 (0x00007f3bd5914000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f3bd56f8000)
        libm.so.6 => /lib64/libm.so.6 (0x00007f3bd53f6000)
        libc.so.6 => /lib64/libc.so.6 (0x00007f3bd5034000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f3bd60ef000)
</pre>